### PR TITLE
Add integration with ViewIt, an API for cross-plugin scoreboard support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,13 @@
     <project.build.number></project.build.number>
   </properties>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>maven2</id>
+      <url>https://repo.maven.apache.org/maven2/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <repositories>
     <repository>
       <id>dmulloy2-repo</id>
@@ -80,7 +87,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -176,6 +183,11 @@
       <groupId>com.comphenix.protocol</groupId>
       <artifactId>ProtocolLib</artifactId>
       <version>3.6.4</version>
+    </dependency>
+    <dependency>
+      <groupId>net.t7seven7t.viewit</groupId>
+      <artifactId>ViewIt</artifactId>
+      <version>3</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/net/dmulloy2/ultimatearena/UltimateArena.java
+++ b/src/main/java/net/dmulloy2/ultimatearena/UltimateArena.java
@@ -73,6 +73,7 @@ import net.dmulloy2.ultimatearena.handlers.SpectatingHandler;
 import net.dmulloy2.ultimatearena.integration.EssentialsHandler;
 import net.dmulloy2.ultimatearena.integration.ProtocolHandler;
 import net.dmulloy2.ultimatearena.integration.VaultHandler;
+import net.dmulloy2.ultimatearena.integration.ViewItHandler;
 import net.dmulloy2.ultimatearena.integration.WorldEditHandler;
 import net.dmulloy2.ultimatearena.listeners.BlockListener;
 import net.dmulloy2.ultimatearena.listeners.EntityListener;
@@ -123,6 +124,7 @@ public class UltimateArena extends SwornPlugin implements Reloadable
 	private @Getter WorldEditHandler worldEditHandler;
 	private @Getter ProtocolHandler protocolHandler;
 	private @Getter VaultHandler vaultHandler;
+	private @Getter ViewItHandler viewItHandler;
 
 	// Public lists and maps
 	private @Getter Map<String, ArenaJoinTask> waiting = new HashMap<>();
@@ -306,6 +308,14 @@ public class UltimateArena extends SwornPlugin implements Reloadable
 		{
 			worldEditHandler = new WorldEditHandler(this);
 		} catch (Throwable ex) { }
+
+		try
+		{
+			if (getConfig().getBoolean("enableViewItIntegration"))
+			{
+				viewItHandler = new ViewItHandler(this);
+			}
+		} catch (Throwable ex) { }
 	}
 
 	public final boolean isEssentialsEnabled()
@@ -326,6 +336,11 @@ public class UltimateArena extends SwornPlugin implements Reloadable
 	public final boolean isWorldEditEnabled()
 	{
 		return worldEditHandler != null && worldEditHandler.isEnabled();
+	}
+
+	public final boolean isViewItEnabled()
+	{
+		return viewItHandler != null && viewItHandler.isEnabled();
 	}
 
 	// Loading

--- a/src/main/java/net/dmulloy2/ultimatearena/arenas/Arena.java
+++ b/src/main/java/net/dmulloy2/ultimatearena/arenas/Arena.java
@@ -139,6 +139,7 @@ public abstract class Arena implements Reloadable
 	protected boolean inLobby;
 	protected boolean inGame;
 
+	@Getter
 	protected String name;
 
 	protected Mode gameMode = Mode.IDLE;
@@ -280,6 +281,14 @@ public abstract class Arena implements Reloadable
 		{
 			ClassSelectionGUI csGUI = new ClassSelectionGUI(plugin, player);
 			plugin.getGuiHandler().open(player, csGUI);
+		}
+
+		if (plugin.isViewItEnabled()) {
+			if (gameMode == Mode.LOBBY) {
+				plugin.getViewItHandler().addLobbyElements(player);
+			} else if (gameMode == Mode.INGAME){
+				plugin.getViewItHandler().addIngameElements(player);
+			}
 		}
 
 		tellPlayers("&a{0} has joined the arena! ({1}/{2})", pl.getName(), active.size(), maxPlayers);
@@ -871,6 +880,10 @@ public abstract class Arena implements Reloadable
 		if (! disconnected)
 			inactive.add(ap);
 
+		if (plugin.isViewItEnabled()) {
+			plugin.getViewItHandler().removeAllElements(ap.getPlayer());
+		}
+
 		// Add them to the final leaderboard if applicable
 		if (finalLeaderboard != null)
 		{
@@ -990,6 +1003,13 @@ public abstract class Arena implements Reloadable
 
 			this.gameTimer = maxGameTime;
 			this.startTimer = -1;
+
+			if (plugin.isViewItEnabled()) {
+				for (ArenaPlayer ap : active) {
+					plugin.getViewItHandler().removeAllElements(ap.getPlayer());
+					plugin.getViewItHandler().addIngameElements(ap.getPlayer());
+				}
+			}
 
 			onStart();
 			spawnAll();
@@ -1522,5 +1542,20 @@ public abstract class Arena implements Reloadable
 	public String toString()
 	{
 		return name;
+	}
+
+	public Mode getGameMode() {
+		return gameMode;
+	}
+
+	public int getRemainingTime() {
+		switch (gameMode) {
+			case LOBBY:
+				return startTimer;
+			case INGAME:
+				return gameTimer;
+			default:
+				return -1;
+		}
 	}
 }

--- a/src/main/java/net/dmulloy2/ultimatearena/integration/ViewItHandler.java
+++ b/src/main/java/net/dmulloy2/ultimatearena/integration/ViewItHandler.java
@@ -1,3 +1,21 @@
+/**
+ * UltimateArena - fully customizable PvP arenas
+ * Copyright (C) 2012 - 2015 MineSworn
+ * Copyright (C) 2013 - 2015 dmulloy2
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package net.dmulloy2.ultimatearena.integration;
 
 import com.google.common.base.Function;

--- a/src/main/java/net/dmulloy2/ultimatearena/integration/ViewItHandler.java
+++ b/src/main/java/net/dmulloy2/ultimatearena/integration/ViewItHandler.java
@@ -1,0 +1,186 @@
+package net.dmulloy2.ultimatearena.integration;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import net.dmulloy2.integration.DependencyProvider;
+import net.dmulloy2.ultimatearena.UltimateArena;
+import net.dmulloy2.ultimatearena.arenas.Arena;
+import net.dmulloy2.ultimatearena.types.ArenaPlayer;
+import net.t7seven7t.viewit.ViewItPlugin;
+import net.t7seven7t.viewit.replacer.Replacer;
+import net.t7seven7t.viewit.replacer.Replacers;
+import net.t7seven7t.viewit.scoreboard.ScoreboardElement;
+import net.t7seven7t.viewit.scoreboard.ScoreboardService;
+import net.t7seven7t.viewit.supply.FrameSupply;
+import net.t7seven7t.viewit.supply.Supply;
+
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import static net.t7seven7t.viewit.scoreboard.ScoreboardElement.Priority.HIGH;
+
+/**
+ * Handle scoreboard integration
+ *
+ * @author t7seven7t
+ */
+public class ViewItHandler extends DependencyProvider<ViewItPlugin> {
+
+    private static UltimateArena plugin;
+
+    private List<ScoreboardElement> ingameElements;
+    private List<ScoreboardElement> lobbyElements;
+
+    public ViewItHandler(UltimateArena plugin) {
+        super(plugin, "ViewIt");
+    }
+
+    @Override
+    public void onEnable() {
+        plugin = (UltimateArena) handler;
+
+        registerReplacer("UA_remaining_time", Functions.REMAINING_TIME);
+        registerReplacer("UA_game_status", Functions.GAME_STATUS);
+        registerReplacer("UA_game_name", Functions.GAME_NAME);
+        registerReplacer("UA_player_class", Functions.PLAYER_CLASS);
+        registerReplacer("UA_player_deaths", Functions.PLAYER_DEATHS);
+        registerReplacer("UA_player_kdr", Functions.PLAYER_KDR);
+        registerReplacer("UA_player_kills", Functions.PLAYER_KILLS);
+        registerReplacer("UA_player_killstreak", Functions.PLAYER_KILLSTREAK);
+
+        lobbyElements = Lists.newArrayList();
+        lobbyElements.add(makeElement(HIGH(13), 10000L, Supply.of("&8[-------&4UA&8-------]")));
+        lobbyElements.add(makeElement(HIGH(12), 600L, Supply.of("&6Arena: &a%UA_game_name%")));
+        lobbyElements.add(makeElement(HIGH(11), 20L, Supply.of("&6Status: &a%UA_game_status%")));
+        lobbyElements.add(
+                makeElement(HIGH(10), 20L, Supply.of("&6Time left: &9%UA_remaining_time%")));
+        lobbyElements.add(makeElement(HIGH(5), 10000L, Supply.of("&8[-------&4UA&8-------]")));
+
+        ingameElements = Lists.newArrayList();
+        ingameElements.addAll(lobbyElements);
+        ingameElements.add(makeElement(HIGH(9), 20L, Supply.of("&6Kills: &a%UA_player_kills%")));
+        ingameElements.add(makeElement(HIGH(8), 20L, Supply.of("&6Deaths: &a%UA_player_deaths%")));
+        ingameElements.add(makeElement(HIGH(7), 20L,
+                Supply.of("&6Killstreak: &a%UA_player_killstreak%")));
+        ingameElements.add(makeElement(HIGH(6), 20L, Supply.of("&6Class: &a%UA_player_class%")));
+    }
+
+    public void addLobbyElements(Player player) {
+        getInstance().addElements(player,
+                lobbyElements.toArray(new ScoreboardElement[lobbyElements.size()]));
+    }
+
+    public void removeAllElements(Player player) {
+        getInstance().removeElements(player,
+                ingameElements.toArray(new ScoreboardElement[ingameElements.size()]));
+    }
+
+    public void addIngameElements(Player player) {
+        getInstance().addElements(player,
+                ingameElements.toArray(new ScoreboardElement[ingameElements.size()]));
+    }
+
+    private void registerReplacer(String replace, final Function<Player, String> function) {
+        Replacers.registerReplacer(new Replacer(replace) {
+            @Override
+            public String getResult(Player player, Player player1) {
+                return function.apply(player);
+            }
+        });
+    }
+
+    private ScoreboardElement makeElement(ScoreboardElement.Priority priority, long updateDelay,
+                                          FrameSupply... contents) {
+        return ViewItPlugin.getInstance().of(plugin, priority.intValue(), updateDelay,
+                Arrays.asList(contents));
+    }
+
+    private ScoreboardElement makeElement(ScoreboardElement.Priority priority, long updateDelay,
+                                          List<FrameSupply> contents) {
+        return ViewItPlugin.getInstance().of(plugin, priority.intValue(), updateDelay, contents);
+    }
+
+    private ScoreboardService getInstance() {
+        return ViewItPlugin.getInstance().getScoreboardService();
+    }
+
+    private static class Functions {
+        private static Function<Player, String> REMAINING_TIME = new Function<Player, String>() {
+            @Nullable
+            @Override
+            public String apply(Player player) {
+                return getArena(player).getRemainingTime() + "s";
+            }
+        };
+
+        private static Function<Player, String> GAME_NAME = new Function<Player, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable Player player) {
+                return getArena(player).getName();
+            }
+        };
+
+        private static Function<Player, String> GAME_STATUS = new Function<Player, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable Player player) {
+                return getArena(player).getStatus();
+            }
+        };
+
+        private static Function<Player, String> PLAYER_KDR = new Function<Player, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable Player player) {
+                return getArenaPlayer(player).getKDR() + "";
+            }
+        };
+
+        private static Function<Player, String> PLAYER_KILLS = new Function<Player, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable Player player) {
+                return getArenaPlayer(player).getKills() + "";
+            }
+        };
+
+        private static Function<Player, String> PLAYER_DEATHS = new Function<Player, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable Player player) {
+                return getArenaPlayer(player).getDeaths() + "";
+            }
+        };
+
+        private static Function<Player, String> PLAYER_KILLSTREAK = new Function<Player, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable Player player) {
+                return getArenaPlayer(player).getKillStreak() + "";
+            }
+        };
+
+        private static Function<Player, String> PLAYER_CLASS = new Function<Player, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable Player player) {
+                return getArenaPlayer(player).getArenaClass().getName();
+            }
+        };
+
+        private static Arena getArena(Player player) {
+            return plugin.getArena(player);
+        }
+
+        private static ArenaPlayer getArenaPlayer(Player player) {
+            return plugin.getArenaPlayer(player);
+        }
+    }
+
+}

--- a/src/main/java/net/dmulloy2/ultimatearena/types/ArenaClass.java
+++ b/src/main/java/net/dmulloy2/ultimatearena/types/ArenaClass.java
@@ -81,6 +81,7 @@ public final class ArenaClass extends Configuration
 
 	// ---- Transient
 	private transient File file;
+	@Getter
 	private transient String name;
 	private transient boolean loaded;
 

--- a/src/main/java/net/dmulloy2/ultimatearena/types/ArenaPlayer.java
+++ b/src/main/java/net/dmulloy2/ultimatearena/types/ArenaPlayer.java
@@ -61,8 +61,11 @@ import org.bukkit.potion.PotionEffect;
 @Getter @Setter
 public final class ArenaPlayer
 {
+	@Getter
 	private int kills;
+	@Getter
 	private int deaths;
+	@Getter
 	private int killStreak;
 	private int gameXP;
 	private int amtKicked;
@@ -71,6 +74,7 @@ public final class ArenaPlayer
 	private boolean canReward;
 	private boolean changeClassOnRespawn;
 
+	@Getter
 	private Team team = Team.RED;
 	private List<Double> transactions = new ArrayList<>();
 	private Map<String, Object> data = new HashMap<>();
@@ -80,6 +84,7 @@ public final class ArenaPlayer
 	private UUID uniqueId;
 	private Location spawnBack;
 
+	@Getter
 	private ArenaClass arenaClass;
 	private PlayerData playerData;
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -79,3 +79,7 @@ forceRespawn: false
 # Whether or not to show unavailable classes in the GUI
 # Input: boolean; default: false
 showUnavailableClasses: false
+
+# If ViewIt is enabled UltimateArena will use its scoreboard API
+# You can download ViewIt at: https://github.com/t7seven7t/ViewIt/releases
+enableViewItIntegration: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: UltimateArena
 main: net.dmulloy2.ultimatearena.UltimateArena
 version: ${project.version}${project.build.number}
 author: dmulloy2
-softdepend: [WorldEdit, Vault, Essentials, Multiverse-Core, MyWorlds, ProtocolLib]
+softdepend: [WorldEdit, Vault, Essentials, Multiverse-Core, MyWorlds, ProtocolLib, ViewIt]
 description: The Ultimate in Minecraft death sports and spleef!
 load: postworld
 commands:


### PR DESCRIPTION
ViewIt is a new [fully open source](https://github.com/t7seven7t/ViewIt) scoreboard API with a focus on making scoreboards compatible between plugins. I think it'd be great if UA supported it by default.

This PR is just a proof of concept at the moment but can be continued to become a feature of UA.

Here is an example of what I've made the scoreboard look like while in the lobby.
![](https://i.gyazo.com/5d3d93fe71472896531685f8a5842f89.gif)
I don't have a picture of the ingame scoreboard because I haven't been able to test with a second player but it adds scores about the player's class, kills, deaths and current killstreak (it displays for half a second when I force start the arena but alas too short for me to screen cap it).

If you like this idea perhaps I can add support for all the arena types. Having a score for the current wave in a mob arena or the number of remaining tickets in conquest may be useful to have and could mean adding an option for cutting down chat spam.

Does UltimateArena have localization support? Maybe we could make the scoreboard text configurable.

The releases are here if you want to test it out for yourself:
https://github.com/t7seven7t/UltimateArena/releases/tag/3.0-v3
https://github.com/t7seven7t/ViewIt/releases